### PR TITLE
Allow rack-test upgrades

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', version
 
   s.add_dependency 'rack',      '~> 2.0'
-  s.add_dependency 'rack-test', '~> 0.6.3'
+  s.add_dependency 'rack-test', '>= 0.6.3'
   s.add_dependency 'rails-html-sanitizer', '~> 1.0', '>= 1.0.2'
   s.add_dependency 'rails-dom-testing', '~> 2.0'
   s.add_dependency 'actionview', version


### PR DESCRIPTION
Backport [#29859](https://github.com/rails/rails/pull/29859) to enable rack-test upgrades.

`rack-test` is by far our most out-of-date dependency (7.5 years!) and is pinned by our Rails version. Given that we've forked Rails anyways, we may as well loosen this constraint of this test dependency (which has been done on Rails master anyways since Rails 5.2).